### PR TITLE
【Fixed】issue#3実装完了しました

### DIFF
--- a/app/controllers/agendas_controller.rb
+++ b/app/controllers/agendas_controller.rb
@@ -1,5 +1,5 @@
 class AgendasController < ApplicationController
-  # before_action :set_agenda, only: %i[show edit update destroy]
+  before_action :set_agenda, only: %i[destroy]
 
   def index
     @agendas = Agenda.all
@@ -18,6 +18,19 @@ class AgendasController < ApplicationController
       redirect_to dashboard_url, notice: I18n.t('views.messages.create_agenda')
     else
       render :new
+    end
+  end
+
+  def destroy
+    if current_user.id == @agenda.user_id || current_user.id == @agenda.team.owner.id
+      @agenda.destroy
+      @users = User.where(keep_team_id: @agenda.team_id)
+      @users.each do |user|
+        AssignMailer.agenda_delete_mail(user).deliver
+      end
+      redirect_to dashboard_url, notice: I18n.t('views.messages.delete_agenda')
+    else
+      redirect_to dashboard_url, notice: I18n.t('views.messages.non_delete_agenda')
     end
   end
 

--- a/app/mailers/assign_mailer.rb
+++ b/app/mailers/assign_mailer.rb
@@ -11,4 +11,9 @@ class AssignMailer < ApplicationMailer
     @email = email
     mail to: @email, subject: I18n.t('views.messages.change_owner')
   end
+
+  def agenda_delete_mail(email)
+    @email = email
+    mail to: @email, subject: I18n.t('views.messages.agenda_delete_mail')
+  end
 end

--- a/app/views/assign_mailer/agenda_delete_mail.html.erb
+++ b/app/views/assign_mailer/agenda_delete_mail.html.erb
@@ -1,0 +1,3 @@
+<h1><%= I18n.t('views.messages.delete_agenda') %></h1>
+
+<h4>email: <%= @email.email %></h4>

--- a/app/views/shared/layout/_sidebar.html.erb
+++ b/app/views/shared/layout/_sidebar.html.erb
@@ -37,6 +37,7 @@
                 <i class="right fa fa-angle-left"></i>
               </p>
             </a>
+            <object><%= button_to I18n.t('views.button.delete'), agenda_path(agenda), method: :delete, class: 'btn btn-sm btn-danger' %></object>
             <ul class="nav nav-treeview" style="display: block;">
               <% agenda.articles.each do |article| %>
                 <li class="nav-item">

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -208,6 +208,8 @@ ja:
       create_agenda: 'アジェンダ作成に成功しました！'
       create_article: '記事作成に成功しました！'
       update_article: '記事更新に成功しました！'
+      delete_agenda: 'アジェンダを削除しました！'
+      non_delete_agenda: 'このアジェンダは削除できません'
       assigned: 'アサインしました！'
       failed_to_assign: 'アサインに失敗しました！'
       email_already_exists: 'すでに同じメールアドレスが登録されています!'


### PR DESCRIPTION
AgendasControllerのdestroyアクションを追加し、そこに機能追加する
Agendaの名前の右の部分に削除ボタンを作成し、そのボタンを押すとそのAgendaが削除される
Agendaに紐づいているarticleも一緒に削除される
Agendaを削除できるのは、そのAgendaの作者もしくはそのAgendaに紐づいているTeamの作者（オーナー）のみ
Agendaが削除されると、そのAgendaに紐づいているTeamに所属しているユーザー全員に通知メールが飛ぶ
情報処理が完了した後はDashBoardに飛ぶ
その他、アプリケーションの挙動に不審な点やエラーがないこと